### PR TITLE
Refactored MetricsDefinition to use a MetricBuilder and be based off a super class

### DIFF
--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/Metric.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/Metric.java
@@ -1,0 +1,124 @@
+/*
+ *   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package software.amazon.cloudwatchlogs.emf.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionFilter;
+import software.amazon.cloudwatchlogs.emf.serializers.StorageResolutionSerializer;
+import software.amazon.cloudwatchlogs.emf.serializers.UnitDeserializer;
+import software.amazon.cloudwatchlogs.emf.serializers.UnitSerializer;
+
+/** Abstract immutable (except for name) class that all Metrics are based on. */
+@Getter
+public abstract class Metric<V> {
+    @JsonProperty("Name")
+    @Setter(AccessLevel.PROTECTED)
+    @NonNull
+    protected String name;
+
+    @JsonProperty("Unit")
+    @JsonSerialize(using = UnitSerializer.class)
+    @JsonDeserialize(using = UnitDeserializer.class)
+    protected Unit unit;
+
+    @JsonProperty("StorageResolution")
+    @JsonInclude(
+            value = JsonInclude.Include.CUSTOM,
+            valueFilter =
+                    StorageResolutionFilter.class) // Do not serialize when valueFilter is true
+    @JsonSerialize(using = StorageResolutionSerializer.class)
+    protected StorageResolution storageResolution;
+
+    @JsonIgnore @Getter protected V values;
+
+    /** @return the values of this metric formatted to be flushed */
+    protected Object getFormattedValues() {
+        return this.getValues();
+    }
+
+    /**
+     * Creates a Metric with the first {@code size} values of the current metric
+     *
+     * @param size the maximum size of the returned metric's values
+     * @return a Metric with the first {@code size} values of the current metric.
+     */
+    protected abstract Metric getMetricValuesUnderSize(int size);
+
+    /**
+     * Creates a Metric all metrics after the first {@code size} values of the current metric. If
+     * there are less than {@code size} values, null is returned.
+     *
+     * @param size the maximum size of the returned metric's values
+     * @return a Metric with the all metrics after the first {@code size} values of the current
+     *     metric. If there are less than {@code size} values, null is returned.
+     */
+    protected abstract Metric getMetricValuesOverSize(int size);
+
+    public abstract static class MetricBuilder<V, T extends MetricBuilder<V, T>> extends Metric<V> {
+
+        protected abstract T getThis();
+
+        /**
+         * Adds a value to the metric.
+         *
+         * @param value the value to be added to this metric
+         */
+        abstract T addValue(double value);
+
+        /**
+         * Builds the metric.
+         *
+         * @return the built metric
+         */
+        abstract Metric build();
+
+        protected T name(@NonNull String name) {
+            this.name = name;
+            return getThis();
+        }
+
+        public T unit(Unit unit) {
+            this.unit = unit;
+            return getThis();
+        }
+
+        public T storageResolution(StorageResolution storageResolution) {
+            this.storageResolution = storageResolution;
+            return getThis();
+        }
+
+        protected Metric getMetricValuesOverSize(int size) {
+            return build().getMetricValuesOverSize(size);
+        }
+
+        protected Metric getMetricValuesUnderSize(int size) {
+            return build().getMetricValuesUnderSize(size);
+        }
+
+        protected Object getFormattedValues() {
+            return build().getFormattedValues();
+        }
+    }
+}

--- a/src/main/java/software/amazon/cloudwatchlogs/emf/model/RootNode.java
+++ b/src/main/java/software/amazon/cloudwatchlogs/emf/model/RootNode.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.AllArgsConstructor;
@@ -66,9 +65,8 @@ class RootNode {
         targetMembers.putAll(properties);
         targetMembers.putAll(getDimensions());
         for (MetricDirective metricDirective : aws.getCloudWatchMetrics()) {
-            for (MetricDefinition metric : metricDirective.getMetrics().values()) {
-                List<Double> values = metric.getValues();
-                targetMembers.put(metric.getName(), values.size() == 1 ? values.get(0) : values);
+            for (Metric metric : metricDirective.getMetrics().values()) {
+                targetMembers.put(metric.getName(), metric.getFormattedValues());
             }
         }
         return targetMembers;
@@ -85,7 +83,7 @@ class RootNode {
         return dimensions;
     }
 
-    Map<String, MetricDefinition> metrics() {
+    Map<String, Metric> metrics() {
         return aws.getCloudWatchMetrics().get(0).getMetrics();
     }
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDefinitionTest.java
@@ -24,11 +24,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Test;
 
-public class MetricDefinitionTest {
+class MetricDefinitionTest {
 
     @Test(expected = NullPointerException.class)
     public void testThrowExceptionIfNameIsNull() {
-        new MetricDefinition(null);
+        MetricDefinition.MetricDefinitionBuilder builder = MetricDefinition.builder();
+        builder.setName(null);
     }
 
     @Test
@@ -36,7 +37,11 @@ public class MetricDefinitionTest {
             throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         MetricDefinition metricDefinition =
-                new MetricDefinition("Time", StorageResolution.HIGH, 10);
+                MetricDefinition.builder()
+                        .storageResolution(StorageResolution.HIGH)
+                        .addValue(10)
+                        .name("Time")
+                        .build();
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\",\"StorageResolution\":1}", metricString);
@@ -46,7 +51,12 @@ public class MetricDefinitionTest {
     public void testSerializeMetricDefinitionWithUnitWithoutStorageResolution()
             throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        MetricDefinition metricDefinition = new MetricDefinition("Time", Unit.MILLISECONDS, 10);
+        MetricDefinition metricDefinition =
+                MetricDefinition.builder()
+                        .unit(Unit.MILLISECONDS)
+                        .addValue(10)
+                        .name("Time")
+                        .build();
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals("{\"Name\":\"Time\",\"Unit\":\"Milliseconds\"}", metricString);
@@ -57,7 +67,11 @@ public class MetricDefinitionTest {
             throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         MetricDefinition metricDefinition =
-                new MetricDefinition("Time", StorageResolution.STANDARD, 10);
+                MetricDefinition.builder()
+                        .storageResolution(StorageResolution.STANDARD)
+                        .addValue(10)
+                        .name("Time")
+                        .build();
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\"}", metricString);
@@ -66,7 +80,7 @@ public class MetricDefinitionTest {
     @Test
     public void testSerializeMetricDefinitionWithoutUnit() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
-        MetricDefinition metricDefinition = new MetricDefinition("Time");
+        MetricDefinition metricDefinition = MetricDefinition.builder().name("Time").build();
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals("{\"Name\":\"Time\",\"Unit\":\"None\"}", metricString);
@@ -76,7 +90,12 @@ public class MetricDefinitionTest {
     public void testSerializeMetricDefinition() throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         MetricDefinition metricDefinition =
-                new MetricDefinition("Time", Unit.MILLISECONDS, StorageResolution.HIGH, 10);
+                MetricDefinition.builder()
+                        .unit(Unit.MILLISECONDS)
+                        .storageResolution(StorageResolution.HIGH)
+                        .addValue(10)
+                        .name("Time")
+                        .build();
         String metricString = objectMapper.writeValueAsString(metricDefinition);
 
         assertEquals(
@@ -86,10 +105,11 @@ public class MetricDefinitionTest {
 
     @Test
     public void testAddValue() {
-        MetricDefinition md = new MetricDefinition("Time", Unit.MICROSECONDS, 10);
-        assertEquals(Collections.singletonList(10d), md.getValues());
+        MetricDefinition.MetricDefinitionBuilder builder =
+                MetricDefinition.builder().unit(Unit.MILLISECONDS).addValue(10).addValue(20);
+        assertEquals(Collections.singletonList(10d), builder.getValues());
 
-        md.addValue(20);
-        assertEquals(Arrays.asList(10d, 20d), md.getValues());
+        builder.addValue(20);
+        assertEquals(Arrays.asList(10d, 20d), builder.getValues());
     }
 }

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveTest.java
@@ -71,7 +71,10 @@ class MetricDirectiveTest {
         metricDirective.putMetric("Time", 20);
 
         Assertions.assertEquals(1, metricDirective.getAllMetrics().size());
-        MetricDefinition[] mds = metricDirective.getAllMetrics().toArray(new MetricDefinition[0]);
+        MetricDefinition.MetricDefinitionBuilder[] mds =
+                metricDirective
+                        .getAllMetrics()
+                        .toArray(new MetricDefinition.MetricDefinitionBuilder[0]);
         Assertions.assertEquals(Arrays.asList(10d, 20d), mds[0].getValues());
     }
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveThreadSafetyTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricDirectiveThreadSafetyTest.java
@@ -3,6 +3,7 @@ package software.amazon.cloudwatchlogs.emf.model;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
+import java.util.List;
 import org.junit.After;
 import org.junit.Test;
 
@@ -50,7 +51,10 @@ public class MetricDirectiveThreadSafetyTest {
         assertEquals(metricDirective.getAllMetrics().size(), N_THREAD * N_PUT_METRIC);
         for (int i = 0; i < N_THREAD * N_PUT_METRIC; i++) {
             assertEquals(
-                    metricDirective.getMetrics().get("Metric-" + i).getValues().get(0), i, 1e-5);
+                    ((List<Double>) metricDirective.getMetrics().get("Metric-" + i).getValues())
+                            .get(0),
+                    i,
+                    1e-5);
         }
     }
 
@@ -86,10 +90,11 @@ public class MetricDirectiveThreadSafetyTest {
         }
 
         assertEquals(1, metricDirective.getAllMetrics().size());
-        MetricDefinition md = metricDirective.getAllMetrics().toArray(new MetricDefinition[0])[0];
-        Collections.sort(md.getValues());
+        Metric md = metricDirective.getAllMetrics().toArray(new Metric[0])[0];
+        List<Double> values = (List<Double>) md.getValues();
+        Collections.sort(values);
         for (int i = 0; i < N_THREAD * N_PUT_METRIC; i++) {
-            assertEquals(md.getValues().get(i), i, 1e-5);
+            assertEquals(values.get(i), i, 1e-5);
         }
     }
 

--- a/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
+++ b/src/test/java/software/amazon/cloudwatchlogs/emf/model/MetricsContextTest.java
@@ -48,8 +48,8 @@ class MetricsContextTest {
 
         List<MetricDefinition> metrics = parseMetrics(events.get(0));
         Assertions.assertEquals(metrics.size(), metricCount);
-        for (MetricDefinition metric : metrics) {
-            MetricDefinition originalMetric = mc.getRootNode().metrics().get(metric.getName());
+        for (Metric metric : metrics) {
+            Metric originalMetric = mc.getRootNode().metrics().get(metric.getName());
             Assertions.assertEquals(originalMetric.getName(), metric.getName());
             Assertions.assertEquals(originalMetric.getUnit(), metric.getUnit());
         }
@@ -73,8 +73,9 @@ class MetricsContextTest {
             allMetrics.addAll(parseMetrics(event));
         }
         Assertions.assertEquals(metricCount, allMetrics.size());
-        for (MetricDefinition metric : allMetrics) {
-            MetricDefinition originalMetric = mc.getRootNode().metrics().get(metric.getName());
+        for (Metric metric : allMetrics) {
+            Metric originalMetric = mc.getRootNode().metrics().get(metric.getName());
+
             Assertions.assertEquals(originalMetric.getName(), metric.getName());
             Assertions.assertEquals(originalMetric.getUnit(), metric.getUnit());
         }
@@ -202,10 +203,20 @@ class MetricsContextTest {
             Object value = rootNode.get(name);
             if (value instanceof ArrayList) {
                 metricDefinitions.add(
-                        new MetricDefinition(
-                                name, unit, StorageResolution.STANDARD, (ArrayList) value));
+                        MetricDefinition.builder()
+                                .name(name)
+                                .unit(unit)
+                                .storageResolution(StorageResolution.STANDARD)
+                                .values((ArrayList) value)
+                                .build());
             } else {
-                metricDefinitions.add(new MetricDefinition(name, unit, (double) value));
+                metricDefinitions.add(
+                        MetricDefinition.builder()
+                                .name(name)
+                                .unit(unit)
+                                .storageResolution(StorageResolution.STANDARD)
+                                .addValue((double) value)
+                                .build());
             }
         }
         return metricDefinitions;


### PR DESCRIPTION
Refactored the MetricDefinition to inherit a Metric super class which can be inherited by other type of metrics (coming soon). Also refactored MetricDefinition to be immutable and created a MetricDefinitionBuilder which behaves similar to how MetricDefinition used to.

Naming is also handled using a setter instead of on creation for simplicity in upcoming metric changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.